### PR TITLE
删除npmrc中的淘宝镜像源

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
-electron_mirror="https://npm.taobao.org/mirrors/electron/"
-electron-builder-binaries_mirror="https://npm.taobao.org/mirrors/electron-builder-binaries/"
 node-linker=hoisted
 public-hoist-pattern=*
 shamefully-hoist=true


### PR DESCRIPTION
删除npmrc中的淘宝镜像源

原淘宝镜像源失效，导致pnpm i无法正常拉取依赖